### PR TITLE
Phase1 Keycloak

### DIFF
--- a/.github/workflows/phase_1_keycloak.yml
+++ b/.github/workflows/phase_1_keycloak.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Generate SBOM with Trivy
         run: |
           /tmp/trivy fs \
-            --timeout 15m0s \
+            --timeout 20m0s \
             --parallel 0 \
             --format cyclonedx \
             --output /tmp/keycloak-sbom.cdx.json \
             keycloak-${KEYCLOAK_TAG}
 
           /tmp/trivy fs \
-            --timeout 15m0s \
+            --timeout 20m0s \
             --parallel 0 \
             --format spdx-json \
             --output /tmp/keycloak-sbom.spdx.json \

--- a/.github/workflows/phase_1_keycloak.yml
+++ b/.github/workflows/phase_1_keycloak.yml
@@ -1,0 +1,101 @@
+---
+name: Phase 1 - Keycloak
+on: [push]
+
+env:
+  TRIVY_VERSION: 0.54.1
+  KEYCLOAK_TAG: 25.0.4
+  SBOMQS_VERSION: 0.1.9
+
+jobs:
+  Keycloak:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Trivy
+        run: |
+          curl -L -o /tmp/trivy.tgz \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          tar xvf /tmp/trivy.tgz -C /tmp
+          chmod +x /tmp/trivy
+
+      - name: Checkout Keycloak
+        run: |
+          curl -L -o /tmp/keycloak.tgz \
+            "https://github.com/keycloak/keycloak/archive/refs/tags/${KEYCLOAK_TAG}.tar.gz"
+          tar xvf /tmp/keycloak.tgz -C .
+
+      - name: Generate SBOM with Trivy
+        run: |
+          /tmp/trivy fs \
+            --timeout 15m0s \
+            --parallel 0 \
+            --format cyclonedx \
+            --output /tmp/keycloak-sbom.cdx.json \
+            keycloak-${KEYCLOAK_TAG}
+
+          /tmp/trivy fs \
+            --timeout 15m0s \
+            --parallel 0 \
+            --format spdx-json \
+            --output /tmp/keycloak-sbom.spdx.json \
+            keycloak-${KEYCLOAK_TAG}
+
+      - name: Upload CycloneDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: keycloak-sbom-cyclonedx
+          path: "/tmp/keycloak-sbom.cdx.json"
+
+      - name: Upload SPDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: keycloak-sbom-spdx
+          path: "/tmp/keycloak-sbom.spdx.json"
+
+  Enrich:
+    runs-on: ubuntu-latest
+    needs: Keycloak
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Enrich Keycloak CycloneDX
+        run: |
+          echo "Enrichment of CycloneDX not supported."
+
+      - name: Enrich Keycloak SPDX
+        run: |
+          echo "Enrichment of SPDX not supported."
+
+  Assemble:
+    runs-on: ubuntu-latest
+    needs: Enrich
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+
+  Validate:
+    needs: Assemble
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download SBOMs
+        uses: actions/download-artifact@v4
+
+      - name: Install sbomqs
+        run: |
+          curl -L -o /tmp/sbomqs \
+            "https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}/sbomqs-linux-amd64"
+          chmod +x /tmp/sbomqs
+
+      - name: "Display SBOM quality score through sqomqs"
+        run: |
+          for SBOM in $(find . -iname *.json); do
+            /tmp/sbomqs score "$SBOM"
+          done

--- a/.github/workflows/phase_1_keycloak.yml
+++ b/.github/workflows/phase_1_keycloak.yml
@@ -94,8 +94,10 @@ jobs:
             "https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}/sbomqs-linux-amd64"
           chmod +x /tmp/sbomqs
 
-      - name: "Display SBOM quality score through sqomqs"
+      - name: "Display SBOM quality score through sbomqs"
         run: |
+          echo \`\`\` >> ${GITHUB_STEP_SUMMARY}
           for SBOM in $(find . -iname *.json); do
-            /tmp/sbomqs score "$SBOM"
+            /tmp/sbomqs score "$SBOM" >> ${GITHUB_STEP_SUMMARY}
           done
+          echo \`\`\` >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
Initial implementation of Trivy scanning Keycloak dependencies. I attempted to follow @vpetersson's example and structure.

The scan takes quite awhile to run, 15 - 20 minutes per BOM format. I believe this is due to the scale of the project but I'm not 100% sure about that. If anyone has any ideas on how to speed it up then I would be more than happy to try them out. It does appear to capture all of the pom files. I was not seeing any of the npm files getting populated in the BOMs either. The BOMs are quite large though, so we may want to reduce what is getting included in them.

I did not implement adding metadata to the BOM. It seemed like from the ticket that the metadata would be addressed in a follow up PR. If I got that wrong then I can go back in and do that.

The only real tweak I made on Viktor's code was to add a summary output on the last build step. It looks like github will let you populate a markdown file with results. I'm currently just dumping the `sbomqs` output to that file inside of a code block to deal with formatting. Might be nice to add some formatting to that in a later revision.

Closes #16 