### PR TITLE
Phase2 Kubectl

### DIFF
--- a/.github/workflows/phase_2_kubectl.yml
+++ b/.github/workflows/phase_2_kubectl.yml
@@ -1,6 +1,9 @@
 ---
 name: Phase 2 - Kubectl
-on: [push]
+on:
+  push:
+    paths:
+      - github/workflows/phase_2_kubectl.yml
 
 env:
   KUBECTL_TAG: 0.31.1
@@ -47,13 +50,13 @@ jobs:
             kubectl-${KUBECTL_TAG}
 
       - name: Upload Generated CycloneDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: generated-kubectl-sbom-cyclonedx
           path: "/tmp/generated-kubectl-sbom.cdx.json"
 
       - name: Upload Generated SPDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: generated-kubectl-sbom-spdx
           path: "/tmp/generated-kubectl-sbom.spdx.json"
@@ -62,10 +65,10 @@ jobs:
     needs: Generate
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
 
       - name: Install sbomasm
         run: |
@@ -112,13 +115,13 @@ jobs:
               augmented_kubectl-sbom.cdx.json > /tmp/augmented_kubectl-sbom.cdx.json
       
       - name: Upload Augmented SPDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: augmented-kubectl-sbom-spdx
           path: "/tmp/augmented_kubectl-sbom.spdx.json"
 
       - name: Upload Augmented CycloneDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: augmented-kubectl-sbom-cyclonedx
           path: "/tmp/augmented_kubectl-sbom.cdx.json"
@@ -128,10 +131,10 @@ jobs:
     needs: Augment
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
 
       - name: Install parlay
         run: |
@@ -149,13 +152,13 @@ jobs:
             augmented-kubectl-sbom-spdx/augmented_kubectl-sbom.spdx.json > /tmp/enriched_kubectl-sbom.spdx.json
 
       - name: Upload Enriched SPDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: enriched-kubectl-sbom-spdx
           path: "/tmp/enriched_kubectl-sbom.spdx.json"
     
       - name: Upload Enriched CycloneDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: enriched-kubectl-sbom-cyclonedx
           path: "/tmp/enriched_kubectl-sbom.cdx.json"
@@ -166,13 +169,13 @@ jobs:
           cp /tmp/enriched_kubectl-sbom.cdx.json /tmp/final_kubectl-sbom.cdx.json
 
       - name: Upload Final SPDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: final-kubectl-sbom-spdx
           path: "/tmp/final_kubectl-sbom.spdx.json"
 
       - name: Upload Final CycloneDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4
         with:
           name: final-kubectl-sbom-cyclonedx
           path: "/tmp/final_kubectl-sbom.cdx.json"
@@ -181,10 +184,10 @@ jobs:
     needs: Enrich
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
       - name: Download SBOMs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
 
       - name: Install sbomqs
         run: |

--- a/.github/workflows/phase_2_kubectl.yml
+++ b/.github/workflows/phase_2_kubectl.yml
@@ -83,7 +83,7 @@ jobs:
               --supplier 'kubernetes (https://kubernetes.io/kubectl)' \
               --repository 'https://github.com/kubernetes/kubectl' \
               --license 'Apache-2.0 (https://raw.githubusercontent.com/kubernetes/kubectl/refs/heads/master/LICENSE)' \
-              generated-kubectl-sbom-spdx/generated-kubectl-sbom.spdx.json > kubectl-sbom.spdx.json
+              generated-kubectl-sbom-spdx/generated-kubectl-sbom.spdx.json > augmented_kubectl-sbom.spdx.json
 
           # Augment the Generated SPDX with updated primary component information
           /tmp/sbomasm edit --subject primary-component \

--- a/.github/workflows/phase_2_kubectl.yml
+++ b/.github/workflows/phase_2_kubectl.yml
@@ -1,0 +1,201 @@
+---
+name: Phase 2 - Kubectl
+on: [push]
+
+env:
+  KUBECTL_TAG: v0.31.1
+  PARLAY_VERSION: 0.5.1
+  SBOMASM_VERSION: 0.1.5
+  SBOMQS_VERSION: 0.1.9
+  TRIVY_VERSION: 0.54.1
+
+jobs:
+  Generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Trivy
+        run: |
+          curl -L -o /tmp/trivy.tgz \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          tar xvf /tmp/trivy.tgz -C /tmp
+          chmod +x /tmp/trivy
+
+      - name: Checkout Kubectl
+        run: |
+          curl -L -o /tmp/kubectl.tgz \
+            "https://github.com/kubernetes/kubectl/archive/refs/tags/${KUBECTL_TAG}.tar.gz"
+          tar xvf /tmp/kubectl.tgz -C .
+
+      - name: Generate SBOM with Trivy
+        run: |
+          /tmp/trivy fs \
+            --timeout 30m0s \
+            --parallel 0 \
+            --format cyclonedx \
+            --skip-db-update \
+            --offline-scan \
+            --output /tmp/generated-kubectl-sbom.cdx.json \
+            kubectl-${KUBECTL_TAG}
+
+          /tmp/trivy fs \
+            --timeout 30m0s \
+            --parallel 0 \
+            --format spdx-json \
+            --skip-db-update \
+            --offline-scan \
+            --output /tmp/generated-kubectl-sbom.spdx.json \
+            kubectl-${KUBECTL_TAG}
+
+      - name: Upload Generated CycloneDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-kubectl-sbom-cyclonedx
+          path: "/tmp/generated-kubectl-sbom.cdx.json"
+
+      - name: Upload Generated SPDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-kubectl-sbom-spdx
+          path: "/tmp/generated-kubectl-sbom.spdx.json"
+  Augment:
+    runs-on: ubuntu-latest
+    needs: Generate
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Install sbomasm
+        run: |
+          curl -L -o /tmp/sbomasm \
+            "https://github.com/interlynk-io/sbomasm/releases/download/v${SBOMASM_VERSION}/sbomasm-linux-amd64"
+          chmod +x /tmp/sbomasm
+
+      - name: Augment Kubectl SPDX
+        run: |
+          # Augment the Generated SPDX with updated document information
+          #   - Using `--append` option to ensure the author information is appended instead
+          #     of replacing the tool information.
+          /tmp/sbomasm edit --append --subject Document \
+              --author 'CISA Tiger Group for SBOM Generation Reference Implementations' \
+              --supplier 'kubernetes (https://kubernetes.io/kubectl)' \
+              --repository 'https://github.com/kubernetes/kubectl' \
+              --license 'Apache-2.0 (https://raw.githubusercontent.com/kubernetes/kubectl/refs/heads/master/LICENSE)' \
+              generated-kubectl-sbom-spdx/generated-kubectl-sbom.spdx.json > kubectl-sbom.spdx.json
+
+          # Augment the Generated SPDX with updated primary component information
+          /tmp/sbomasm edit --subject primary-component \
+              --supplier 'kubernetes (https://kubernetes.io/kubectl)' \
+              --repository 'https://github.com/kubernetes/kubectl' \
+              --license 'Apache-2.0 (https://raw.githubusercontent.com/kubernetes/kubectl/refs/heads/master/LICENSE)' \
+              augmented_kubectl-sbom.spdx.json > /tmp/augmented_kubectl-sbom.spdx.json
+
+      - name: Augment Kubectl CycloneDX
+        run: |
+          # Augment the Generated CycloneDX with updated document information
+          /tmp/sbomasm edit --subject Document \
+              --author 'CISA Tiger Group for SBOM Generation Reference Implementations' \
+              --supplier 'kubernetes (https://kubernetes.io/kubectl)' \
+              --lifecycle 'pre-build' \
+              --repository 'https://github.com/kubernetes/kubectl' \
+              --license 'Apache-2.0 (https://raw.githubusercontent.com/kubernetes/kubectl/refs/heads/master/LICENSE)' \
+              generated-kubectl-sbom-cyclonedx/generated-kubectl-sbom.cdx.json > augmented_kubectl-sbom.cdx.json
+
+          # Augment the Generated CycloneDX with updated primary component information
+          /tmp/sbomasm edit --subject primary-component \
+              --author 'CISA Tiger Group for SBOM Generation Reference Implementations' \
+              --supplier 'kubernetes (https://kubernetes.io/kubectl)' \
+              --repository 'https://github.com/kubernetes/kubectl' \
+              --license 'Apache-2.0 (https://raw.githubusercontent.com/kubernetes/kubectl/refs/heads/master/LICENSE)' \
+              augmented_kubectl-sbom.cdx.json > /tmp/augmented_kubectl-sbom.cdx.json
+      
+      - name: Upload Augmented SPDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: augmented-kubectl-sbom-spdx
+          path: "/tmp/augmented_kubectl-sbom.spdx.json"
+
+      - name: Upload Augmented CycloneDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: augmented-kubectl-sbom-cyclonedx
+          path: "/tmp/augmented_kubectl-sbom.cdx.json"
+
+  Enrich:
+    runs-on: ubuntu-latest
+    needs: Augment
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Install parlay
+        run: |
+          curl -Ls https://github.com/snyk/parlay/releases/download/v${PARLAY_VERSION}/parlay_Linux_x86_64.tar.gz | tar xvz -C /tmp
+          chmod +x /tmp/parlay
+
+      - name: Enrich Kubectl CycloneDX
+        run: |
+          /tmp/parlay ecosystems enrich \
+            augmented-kubectl-sbom-cyclonedx/augmented_kubectl-sbom.cdx.json > /tmp/enriched_kubectl-sbom.cdx.json
+
+      - name: Enrich Kubectl SPDX
+        run: |
+          /tmp/parlay ecosystems enrich \
+            augmented-kubectl-sbom-spdx/augmented_kubectl-sbom.spdx.json > /tmp/enriched_kubectl-sbom.spdx.json
+
+      - name: Upload Enriched SPDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: enriched-kubectl-sbom-spdx
+          path: "/tmp/enriched_kubectl-sbom.spdx.json"
+    
+      - name: Upload Enriched CycloneDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: enriched-kubectl-sbom-cyclonedx
+          path: "/tmp/enriched_kubectl-sbom.cdx.json"
+
+      - name: Save Final SBOMs
+        run: |
+          cp /tmp/enriched_kubectl-sbom.spdx.json /tmp/final_kubectl-sbom.spdx.json
+          cp /tmp/enriched_kubectl-sbom.cdx.json /tmp/final_kubectl-sbom.cdx.json
+
+      - name: Upload Final SPDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: final-kubectl-sbom-spdx
+          path: "/tmp/final_kubectl-sbom.spdx.json"
+
+      - name: Upload Final CycloneDX SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: final-kubectl-sbom-cyclonedx
+          path: "/tmp/final_kubectl-sbom.cdx.json"
+
+  Validate:
+    needs: Enrich
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download SBOMs
+        uses: actions/download-artifact@v4
+
+      - name: Install sbomqs
+        run: |
+          curl -L -o /tmp/sbomqs \
+            "https://github.com/interlynk-io/sbomqs/releases/download/v${SBOMQS_VERSION}/sbomqs-linux-amd64"
+          chmod +x /tmp/sbomqs
+
+      - name: "Display SBOM quality score through sbomqs"
+        run: |
+          echo \`\`\` >> ${GITHUB_STEP_SUMMARY}
+          for SBOM in $(find . -iname final*.json); do
+            /tmp/sbomqs score "$SBOM" >> ${GITHUB_STEP_SUMMARY}
+          done
+          echo \`\`\` >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/phase_2_kubectl.yml
+++ b/.github/workflows/phase_2_kubectl.yml
@@ -3,7 +3,7 @@ name: Phase 2 - Kubectl
 on: [push]
 
 env:
-  KUBECTL_TAG: v0.31.1
+  KUBECTL_TAG: 0.31.1
   PARLAY_VERSION: 0.5.1
   SBOMASM_VERSION: 0.1.5
   SBOMQS_VERSION: 0.1.9
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Kubectl
         run: |
           curl -L -o /tmp/kubectl.tgz \
-            "https://github.com/kubernetes/kubectl/archive/refs/tags/${KUBECTL_TAG}.tar.gz"
+            "https://github.com/kubernetes/kubectl/archive/refs/tags/v${KUBECTL_TAG}.tar.gz"
           tar xvf /tmp/kubectl.tgz -C .
 
       - name: Generate SBOM with Trivy

--- a/phase_2/README.md
+++ b/phase_2/README.md
@@ -1,0 +1,33 @@
+# Kubectl (Go) SBOM Generation
+
+This workflow illustrates creation of SPDX and CycloneDX SBOMs for a golang application. [Kubectl](https://github.com/kubernetes/kubectl) is used as an example due to its wide use and complexity. The workflow is well commented and can be used as a reference implementation for your own projects.
+
+- [.github/workflows/phase_2_kubectl.yml](../../.github/workflows/phase_2_kubectl.yml)
+
+## Reference Impelementation Objectives
+
+- Create both SPDX and CycloneDX SBOMs using open source tools
+- Showcase the additional SBOM lifecycle steps
+- Provide sample tools and implementation for others to use
+
+![SBOM Lifecycle](../../assets/lifecycle.svg)
+
+- `Generate SBOM with Trivy` Job
+  - __Tool__
+    - [trivy](https://github.com/aquasecurity/trivy)
+  - __Notes__
+    - Analyze the kubectl source code using [trivy](https://github.com/aquasecurity/trivy). There are several great open source sbom generation tools, and this could easily be replaced with a tool of your choice.
+- `Augment Kubectl SPDX` and `Augment Kubectl CycloneDX` Jobs
+  - __Tool__
+    - [sbomasm](https://github.com/interlynk-io/sbomasm)
+  - __Notes__
+    - There is metadata that typically cannot be determined through analysis. This is metadata that needs to be determined by the author of the primary component and author of the SBOM document. Examples of this information are project description, SBOM author, and supplier.
+    - There are multiple ways to augment this metadata, you can use [jq](https://jqlang.github.io/jq/), write a custom application, or merge a static SBOM into a generated one.
+- `Enrich Kubectl SPDX` and `Enrich Kubectl CycloneDX` Jobs
+  - __Tool__
+    - [parlay](https://github.com/snyk/parlay)
+  - __Notes__
+    - SBOM generation tools usually find components and their dependencies by analyzing package manager configuration files. This _usually_ does not provide enough information to meet NTIA minimum elements, and tools like [parlay](https://github.com/snyk/parlay) can enrich components in an SBOM by looking up additional component metadata from external databases.
+- `Display SBOM quality score through sbomqs` Job
+  - __Tool__
+    - [sbomqs](https://github.com/interlynk-io/sbomqs)


### PR DESCRIPTION
This implements a workflow to generate SBOMs for kubectl. I used @douglasdennis 's Keycloak workflow and it just worked OOTB. The SBOMs are all under 30kb, and each step takes <11 seconds.

### Observations

* trivy might not be using the full dep graph vi "go mod graph" because there are only about 8 of the ~80-ish deps that have any 'dependsOn' data


Closes #34